### PR TITLE
FEAT: Handle custom height

### DIFF
--- a/edtsds/src/main/java/id/co/edtslib/edtsds/Util.kt
+++ b/edtsds/src/main/java/id/co/edtslib/edtsds/Util.kt
@@ -41,13 +41,15 @@ object Util {
 
     fun Dialog.applyWindowInset(
         dialogRoot: View,
-        consumeBottomInset: Boolean = true
+        consumeBottomInset: Boolean = true,
+        bottomInset: (Int)->Unit
     ){
         ViewCompat.setOnApplyWindowInsetsListener(dialogRoot){ view, windowInsets ->
             val navBarInset = windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars())
             view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
                 if (consumeBottomInset) bottomMargin = navBarInset.bottom
             }
+            bottomInset(navBarInset.bottom)
             WindowInsetsCompat.CONSUMED
         }
     }

--- a/edtsds/src/main/java/id/co/edtslib/edtsds/bottom/BottomLayoutDialog.kt
+++ b/edtsds/src/main/java/id/co/edtslib/edtsds/bottom/BottomLayoutDialog.kt
@@ -24,7 +24,6 @@ open class BottomLayoutDialog(context: Context, themeResId: Int): Dialog(context
                           themeResId: Int = R.style.BottomLayoutDialog,
                           consumeBottomInset: Boolean = true): BottomLayoutDialog {
             val dialog = BottomLayoutDialog(context, themeResId)
-            dialog.binding.bottomLayout.bottomHeight = height
             dialog.binding.bottomLayout.title = title
             dialog.binding.bottomLayout.tray = tray
             dialog.binding.bottomLayout.cancelable = cancelable
@@ -50,8 +49,12 @@ open class BottomLayoutDialog(context: Context, themeResId: Int): Dialog(context
 
             dialog.setCancelable(cancelable)
             dialog.setCanceledOnTouchOutside(false)
+            dialog.applyWindowInset(contentView, consumeBottomInset){ bottomInset->
+                val isCustomHeight = !(height == LayoutParams.WRAP_CONTENT || height == LayoutParams.MATCH_PARENT)
+                val finalHeight = if (isCustomHeight) height + bottomInset  else height
+                dialog.binding.bottomLayout.bottomHeight = finalHeight
+            }
             dialog.show()
-            dialog.applyWindowInset(contentView, consumeBottomInset)
 
             BottomLayoutDialog.dialog = dialog
 


### PR DESCRIPTION
In android 15 and higher (with 3 button nav bar), custom height on bottom layout dialog could cause the UI not fully visible, some part are below bottom nav, this PR consist of addition of height with bottom inset.
The downside of this solution is in android below 15, the dialog may appear higher as result of bottom inset addition.